### PR TITLE
Fix FFmpeg CDN URLs to prevent 404 errors

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
-import { FFmpeg } from 'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.7/dist/ffmpeg.min.js';
-import { fetchFile } from 'https://cdn.jsdelivr.net/npm/@ffmpeg/util@0.12.2/dist/index.min.js';
+import { FFmpeg } from 'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.6/dist/esm/index.js';
+import { fetchFile } from 'https://cdn.jsdelivr.net/npm/@ffmpeg/util@0.12.2/dist/esm/index.js';
 
 const sourceInput = document.getElementById('sourceInput');
 const fileDrop = document.getElementById('fileDrop');
@@ -50,9 +50,9 @@ const ensureFFmpegLoaded = async () => {
   if (ffmpegReady) return;
   setStatus('Downloading FFmpeg core (~25 MB)…');
   await ffmpeg.load({
-    coreURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.7/dist/ffmpeg-core.js',
-    wasmURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.7/dist/ffmpeg-core.wasm',
-    workerURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.7/dist/ffmpeg-core.worker.js',
+    coreURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.js',
+    wasmURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/core@0.12.6/dist/esm/ffmpeg-core.wasm',
+    workerURL: 'https://cdn.jsdelivr.net/npm/@ffmpeg/ffmpeg@0.12.6/dist/esm/worker.js',
   });
   ffmpeg.on('log', ({ message }) => {
     if (message) {


### PR DESCRIPTION
## Summary
- switch the FFmpeg and fetchFile imports to the CDN ESM bundles that are published
- update the ffmpeg.load configuration to point at the valid 0.12.6 core, wasm, and worker assets
- prevent runtime 404 errors that stopped MP4 and PNG conversions from running

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d4ae837b608332ab987eb5937aa1d4