### PR TITLE
Add language toggle to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="zh">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Any to GIF Pro</title>
+  <title>Any to GIF 专业版</title>
   <link rel="stylesheet" href="styles.css" />
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -11,71 +11,78 @@
 </head>
 <body>
   <header class="app-header">
-    <h1>Any to GIF Pro</h1>
-    <p class="tagline">Convert MP4 / MOV / AVI videos or PNG sequences into optimized GIFs directly in your browser.</p>
+    <div class="language-switch">
+      <label for="languageSelect" data-i18n="languageLabel">语言</label>
+      <select id="languageSelect">
+        <option value="zh">中文</option>
+        <option value="en">English</option>
+      </select>
+    </div>
+    <h1 data-i18n="headerTitle">Any to GIF 专业版</h1>
+    <p class="tagline" data-i18n="tagline">在浏览器中将 MP4 / MOV / AVI 视频或 PNG 序列转换为优化的 GIF。</p>
   </header>
 
   <main class="app">
     <section class="card">
-      <h2>1. Load your source</h2>
-      <p class="hint">Supports H.264 MP4, alpha MOV/AVI, and PNG image sequences with transparency.</p>
+      <h2 data-i18n="stepLoad">1. 选择源文件</h2>
+      <p class="hint" data-i18n="hint">支持 H.264 MP4、带透明通道的 MOV/AVI，以及带透明度的 PNG 图像序列。</p>
       <label class="file-drop" id="fileDrop">
         <input type="file" id="sourceInput" multiple accept="video/mp4,video/quicktime,video/x-msvideo,image/png" />
-        <span class="file-drop__prompt">Click to browse or drop files here</span>
-        <span class="file-drop__info" id="fileInfo">No file selected</span>
+        <span class="file-drop__prompt" data-i18n="fileDropPrompt">点击选择文件或将文件拖放到此处</span>
+        <span class="file-drop__info" id="fileInfo">未选择文件</span>
       </label>
     </section>
 
     <section class="card">
-      <h2>2. Configure output</h2>
+      <h2 data-i18n="stepConfigure">2. 配置输出</h2>
       <form id="optionsForm" class="options-grid">
         <label>
-          <span>Width (px)</span>
-          <input type="number" id="width" min="1" placeholder="Auto" />
+          <span data-i18n="widthLabel">宽度（像素）</span>
+          <input type="number" id="width" min="1" placeholder="自动" data-i18n-placeholder="widthPlaceholder" />
         </label>
         <label>
-          <span>Height (px)</span>
-          <input type="number" id="height" min="1" placeholder="Auto" />
+          <span data-i18n="heightLabel">高度（像素）</span>
+          <input type="number" id="height" min="1" placeholder="自动" data-i18n-placeholder="heightPlaceholder" />
         </label>
         <label>
-          <span>Frame rate (fps)</span>
+          <span data-i18n="frameRateLabel">帧率（fps）</span>
           <input type="number" id="frameRate" min="1" max="60" value="15" />
         </label>
         <label>
-          <span>Quality (1-31)</span>
+          <span data-i18n="qualityLabel">质量（1-31）</span>
           <input type="number" id="quality" min="1" max="31" value="15" />
         </label>
         <label>
-          <span>Loop count</span>
+          <span data-i18n="loopLabel">循环次数</span>
           <input type="number" id="loop" min="0" value="0" />
-          <small>0 means infinite looping</small>
+          <small data-i18n="loopHint">0 表示无限循环</small>
         </label>
       </form>
-      <button class="primary" id="convertBtn" disabled>Convert to GIF</button>
+      <button class="primary" id="convertBtn" disabled data-i18n="convertButton">转换为 GIF</button>
     </section>
 
     <section class="card">
-      <h2>3. Progress</h2>
-      <div class="status" id="status">Waiting for source...</div>
+      <h2 data-i18n="stepProgress">3. 转换进度</h2>
+      <div class="status" id="status">等待源文件...</div>
       <div class="progress">
         <div class="progress__bar" id="progressBar"></div>
       </div>
     </section>
 
     <section class="card" id="resultCard" hidden>
-      <h2>4. Result</h2>
+      <h2 data-i18n="stepResult">4. 转换结果</h2>
       <div class="result">
         <img id="preview" alt="GIF preview" />
         <div class="result__meta">
           <p id="resultDetails"></p>
-          <a id="downloadBtn" class="primary" download="output.gif">Download GIF</a>
+          <a id="downloadBtn" class="primary" download="output.gif" data-i18n="downloadButton">下载 GIF</a>
         </div>
       </div>
     </section>
   </main>
 
   <footer class="app-footer">
-    <p>All conversions happen locally using <a href="https://ffmpegwasm.netlify.app/" target="_blank" rel="noreferrer">FFmpeg.wasm</a>. No uploads required.</p>
+    <p data-i18n="footerNote">所有转换均在本地使用 <a href="https://ffmpegwasm.netlify.app/" target="_blank" rel="noreferrer">FFmpeg.wasm</a> 完成，无需上传。</p>
   </footer>
 
   <script type="module" src="script.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -35,6 +35,35 @@ body {
   margin-bottom: 32px;
 }
 
+.language-switch {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.language-switch label {
+  font-weight: 500;
+}
+
+.language-switch select {
+  font: inherit;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.6);
+  color: inherit;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.language-switch select:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
 .app-header h1 {
   font-size: clamp(2rem, 4vw, 3rem);
   margin-bottom: 12px;


### PR DESCRIPTION
## Summary
- make the landing page default to Chinese and expose a language selector for Chinese and English copy
- add client-side translation handling so UI text, status messages, and results react to the chosen language
- style the language selector to match the existing design system

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_b_68d50313e71083329acc007a701e7c13